### PR TITLE
fix path to downloaded Go archive for docker build arm image

### DIFF
--- a/etc/dockerfile.arm
+++ b/etc/dockerfile.arm
@@ -14,7 +14,7 @@ RUN env DEBIAN_FRONTEND=noninteractive \
 # Install Golang
 RUN wget --quiet https://go.dev/dl/go1.23.4.linux-amd64.tar.gz && \
     rm -rf /usr/local/go && \
-    tar -C /usr/local -xzf go1.18.2.linux-amd64.tar.gz
+    tar -C /usr/local -xzf go1.23.4.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Copy source code


### PR DESCRIPTION
Fix for 

```
=> ERROR [ 5/10] RUN wget --quiet https://go.dev/dl/go1.23.4.linux-amd64.tar.gz &&     rm -rf /usr/local/go &&     tar -C /usr/loc  1.9s 
------                                                                                                                                    
 > [ 5/10] RUN wget --quiet https://go.dev/dl/go1.23.4.linux-amd64.tar.gz &&     rm -rf /usr/local/go &&     tar -C /usr/local -xzf go1.18.2.linux-amd64.tar.gz:                                                                                                                    
1.785 tar (child): go1.18.2.linux-amd64.tar.gz: Cannot open: No such file or directory                                                    
1.785 tar (child): Error is not recoverable: exiting now                                                                                  
1.785 tar: Child returned status 2
1.785 tar: Error is not recoverable: exiting now
------
dockerfile.arm:15
--------------------
  14 |     # Install Golang
  15 | >>> RUN wget --quiet https://go.dev/dl/go1.23.4.linux-amd64.tar.gz && \
  16 | >>>     rm -rf /usr/local/go && \
  17 | >>>     tar -C /usr/local -xzf go1.18.2.linux-amd64.tar.gz
  18 |     ENV PATH=$PATH:/usr/local/go/bin
--------------------
ERROR: failed to solve: process "/bin/sh -c wget --quiet https://go.dev/dl/go1.23.4.linux-amd64.tar.gz &&     rm -rf /usr/local/go &&     tar -C /usr/local -xzf go1.18.2.linux-amd64.tar.gz" did not complete successfully: exit code: 2

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/wn8k5tj5z77dbi1h57ggg4b9z
```

when executing `docker build -t narr.arm -f etc/dockerfile.arm .`